### PR TITLE
Add references to other building blocks to top nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
       - EarthCODE: utilisation-domains/earthcode.md
     - Links:
       - Document References: document-references.md
+  - Resource Discovery: https://eoepca.readthedocs.io/projects/resource-discovery/
+  - Data Access: https://eoepca.readthedocs.io/projects/data-access/
 
 theme:
   # name: mkdocs


### PR DESCRIPTION
Goal: All building block docs pages are featured in the top nav like in this [example](https://eoepca.readthedocs.io/projects/data-access).

<img width="632" alt="image" src="https://github.com/EOEPCA/system-architecture/assets/3404817/2409ed66-bbef-4b95-85c6-c0a97104d658">